### PR TITLE
Mention \expanded, and other improvements

### DIFF
--- a/xetex-reference.tex
+++ b/xetex-reference.tex
@@ -1226,9 +1226,9 @@ Shell escape \ifnum\shellescape>0 is \else is not \fi enabled.
 \xarg{arg one}
 \xarg{arg two}
 \desc{Compares the full expansion of the two token list
-arguments. Expands to zero if they are the same, less than one if the
+arguments. Expands to zero if they are the same, $-1$ if the
 first argument sorts lower (lexicographically) than the second argument,
-and greater than one if vice versa.}
+and~$1$ if vice versa.}
 \endcmd
 
 \begin{example}

--- a/xetex-reference.tex
+++ b/xetex-reference.tex
@@ -555,6 +555,13 @@ output but is slower. Activated ($\ge\mathtt1$) by default.}
 \XeTeXuseglyphmetrics=1 \fbox{a}\fbox{A}\fbox{j}\fbox{J}
 \end{example}
 
+\cmd|\XeTeXgenerateactualtext|
+\xarg{integer}
+\desc{Controls the output of \texttt{/ActualText} entry. Default is 0.
+When set to 1, the \texttt{/ActualText} entry is added to the output PDF
+for better copy/paste and search in PDF viewers.}
+\endcmd
+
 \subsection{OpenType fonts}
 
 \cmd|\XeTeXOTcountscripts|
@@ -1169,6 +1176,12 @@ the specified \xarg{font} to $n/1000$\,em. $n$ is clipped to $\pm1000$.}
 \endcmd
 
 \subsection{Programming}
+
+\cmd|\expanded|
+\xarg{general text}
+\desc{Carries out full expansion of a token list like \texttt{\char`\\message},
+but it is still expandable.}
+\endcmd
 
 \cmd|\ifincsname...(\else...)\fi|
 \desc{\tex conditional to branch true if the expansion occurs within

--- a/xetex-reference.tex
+++ b/xetex-reference.tex
@@ -930,11 +930,11 @@ language (in another script) is present in the text.
 \opteq
 \xarg{interchar class}
 \desc{Assigns a class corresponding to \xarg{interchar class} (range
-0–255) to a \xarg{char slot}. Most characters are class 0 by
+0–4095) to a \xarg{char slot}. Most characters are class 0 by
 default. Class 1 is for CJK ideographs, classes 2 and 3 are CJK
-punctuation. The boundary of a text string is considered class 255,
+punctuation. The boundary of a text string is considered class 4095,
 wherever there is a boundary between a ‘run’ of characters and something
-else — glue, kern, math, box, etc. Special case class 256 is ignored;
+else — glue, kern, math, box, etc. Special case class 4096 is ignored;
 useful for diacritics so I’m told.}
 \endcmd
 

--- a/xetex-reference.tex
+++ b/xetex-reference.tex
@@ -894,7 +894,8 @@ optional keyword:\medskip
 \cmd|\Ucharcat|
 \xarg{number}
 \xarg{catcode}
-\desc{Expands to a character token with slot \meta{number} and \meta{catcode} specified.}
+\desc{Expands to a character token with slot \meta{number} and \meta{catcode} specified.
+The values allowed for \meta{catcode} are: 1--4, 6--8 and 10--13.}
 \endcmd
 
 \begin{example}


### PR DESCRIPTION
* Mention \expanded (https://www.texdev.net/2018/12/06/a-new-primitive-expanded)
* Mention \XeTeXgenerateactualtext (#7)
* \Ucharcat allows catcode 13 (https://www.texdev.net/2018/12/06/bringing-xetex-into-line)
* \XeTeXcharclass allows 4095 (#10)