### PR TITLE
Use char class 4095 as text boundary in example

### DIFF
--- a/xetex-reference.tex
+++ b/xetex-reference.tex
@@ -960,8 +960,8 @@ useful for diacritics so I’m told.}
 \XeTeXinterchartoks \mycharclassA \mycharclassa = {\upshape]}
 
 % between " " and "B":
-\XeTeXinterchartoks 255 \mycharclassB = {\bgroup\color{blue}}
-\XeTeXinterchartoks \mycharclassB 255 = {\egroup}
+\XeTeXinterchartoks 4095 \mycharclassB = {\bgroup\color{blue}}
+\XeTeXinterchartoks \mycharclassB 4095 = {\egroup}
 
 % between "B" and "B":
 \XeTeXinterchartoks \mycharclassB \mycharclassB = {.}


### PR DESCRIPTION
As reported in #10, `\XeTeXcharclass` has allowed classes 0--4096 from 0.99994 (see related line in xetex's [NEWS](http://www.tug.org/svn/texlive/trunk/Build/source/texk/web2c/xetexdir/NEWS?revision=55764&view=markup#l85)).  #12 fixed the doc for `\XeTeXcharclass`, and this PR tries to fix the corresponding example.

This problem was firstly reported in https://sourceforge.net/p/xetex/bugs/176/.