### PR TITLE
Update character class limit from 256 to 4096

### DIFF
--- a/xetex-reference.tex
+++ b/xetex-reference.tex
@@ -992,8 +992,8 @@ useful for diacritics so I’m told.}
 \XeTeXinterchartoks \mycharclassA \mycharclassa = {\upshape]}
 
 % between " " and "B":
-\XeTeXinterchartoks 255 \mycharclassB = {\bgroup\color{blue}}
-\XeTeXinterchartoks \mycharclassB 255 = {\egroup}
+\XeTeXinterchartoks 4095 \mycharclassB = {\bgroup\color{blue}}
+\XeTeXinterchartoks \mycharclassB 4095 = {\egroup}
 
 % between "B" and "B":
 \XeTeXinterchartoks \mycharclassB \mycharclassB = {.}


### PR DESCRIPTION
The character class of space (U+0020) has been set 4095 since XeTeX 0.99994. See https://tug.org/pipermail/xetex/2016-February/026363.html