### PR TITLE
Drop surplus arg of \normaldeviate

### DIFF
--- a/xetex-reference.tex
+++ b/xetex-reference.tex
@@ -1354,7 +1354,6 @@ Also, macro logging is truncated at a depth $\ge$ the parameter value.}
 \subsection{Randomness}
 
 \cmd|\normaldeviate|
-\xarg{number}
 \desc{Generate a normally-distributed random integer with a mean of $0$ and
 standard deviation $65\,536$. That is, about $68$\% of the time, the result
 will be between $−65\,536$ and $65\,536$ (one standard


### PR DESCRIPTION
`\normaldeviate` takes zero arguments.